### PR TITLE
Add and configure Vert.x Maven Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,24 @@ This application was generated using [start.vertx.io](http://start.vertx.io).
 
 ## Building
 
-To launch your tests:
+To run tests:
 ```bash
   ./mvnw clean test
 ```
 
-To package your application:
+To package application:
 ```bash
   ./mvnw clean package
 ```
 
-To run your application:
+To run application:
 ```bash
   ./mvnw clean compile exec:java
+```
+
+To run, redeploy and test without repackaging:
+```bash
+  ./mvnw clean vertx:run
 ```
 
 ## Need help?

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <vertx.version>5.0.4</vertx.version>
     <junit-jupiter.version>5.9.1</junit-jupiter.version>
 
+    <vertx.verticle>com.mrnyax.products.MainVerticle</vertx.verticle>
     <main.verticle>com.mrnyax.products.MainVerticle</main.verticle>
     <launcher.class>io.vertx.launcher.application.VertxApplication</launcher.class>
   </properties>
@@ -76,36 +77,30 @@
           <release>17</release>
         </configuration>
       </plugin>
+
       <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>${maven-shade-plugin.version}</version>
+        <groupId>io.reactiverse</groupId>
+        <artifactId>vertx-maven-plugin</artifactId>
+        <version>2.0.2</version>
         <executions>
           <execution>
-            <phase>package</phase>
+            <id>vmp</id>
             <goals>
-              <goal>shade</goal>
+              <goal>initialize</goal>
+              <goal>package</goal>
             </goals>
-            <configuration>
-              <transformers>
-                <transformer
-                  implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <manifestEntries>
-                    <Main-Class>${launcher.class}</Main-Class>
-                    <Main-Verticle>${main.verticle}</Main-Verticle>
-                  </manifestEntries>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-              </transformers>
-              <outputFile>${project.build.directory}/${project.artifactId}-${project.version}-fat.jar
-              </outputFile>
-            </configuration>
           </execution>
         </executions>
+        <configuration>
+          <redeploy>true</redeploy>
+        </configuration>
       </plugin>
+
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -117,6 +112,7 @@
           </arguments>
         </configuration>
       </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
📌 Summary
This PR integrates the Vert.x Maven Plugin into the project’s build configuration to improve the developer experience. It allows running and redeploying the application directly via Maven without needing to build a fat JAR each time.

Shade plugin is removed in favor of Vert.x Maven Plugin. 

✅ Changes
- Added io.reactiverse:vertx-maven-plugin to pom.xml.
- Configured the plugin with MainVerticle as the entrypoint.
- Enabled redeploy support for automatic hot-reloading on code changes.

🚀 Benefits
- Faster local development workflow (./mvnw clean vertx:run).
- Live reload with redeployment on code/resource changes.
- Simplifies testing and debugging during development.

🔗 References
- Vert.x Maven Plugin Documentation
- [Vert.x Getting Started](https://vertx.io/docs/)